### PR TITLE
feat: 리밸런싱 sell → buy 순서 보장 및 주문 간 대기 시간 추가

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import pytz
 from src.logger import get_logger
 from src.config.env import GOOGLE_SHEET_URL
 from src.sheets.client import GoogleSheetsClient
-from src.allocation import StaticAllocationAgent
+from src.allocation import StaticAllocator
 
 logger = get_logger(__name__)
 
@@ -23,7 +23,7 @@ if __name__ == '__main__':
     allocation_info['ticker'] = allocation_info['ticker'].astype(str)
     allocation_info['weight'] = allocation_info['weight'].astype(float)
 
-    obj = StaticAllocationAgent(account_type=args.account_type, allocation_info=allocation_info)
+    obj = StaticAllocator(account_type=args.account_type, allocation_info=allocation_info)
 
     is_market_open = obj.kis_agent.is_trading_day(kst_date)
     latest_trade_date = pd.to_datetime(

--- a/src/allocation.py
+++ b/src/allocation.py
@@ -1,14 +1,18 @@
+import time
 import pandas as pd
 
 from src.kis.client import KISClient
 from src.logger import get_logger, log_method_call
 logger = get_logger(__name__)
 
-class StaticAllocationAgent():
+ORDER_INTERVAL_SECONDS = 3
+SELL_TO_BUY_WAIT_SECONDS = 30
+
+class StaticAllocator():
     @log_method_call
     def __init__(self, account_type: str, allocation_info: pd.DataFrame, is_test: bool = False) -> None:
         self.account_type = account_type
-        self.kis_agent = KISClient(self.account_type)
+        self.kis_client = KISClient(self.account_type)
         self.allocation_info = allocation_info
         self.is_test = is_test
 
@@ -28,45 +32,57 @@ class StaticAllocationAgent():
 
     @log_method_call
     def run_rebalancing(self, plan_df: pd.DataFrame) -> pd.DataFrame:
+        sells = plan_df[plan_df['required_transaction'] == 'sell']
+        buys = plan_df[plan_df['required_transaction'] == 'buy']
+
         result = []
-        for i in plan_df.index:
-            tmp = plan_df.loc[i].to_dict()
-            if tmp['required_transaction'] is None:
-                continue
-            tmp['enable_quantity'] = self.get_enable_qty(ticker=tmp['ticker'], transaction_type=tmp['required_transaction'])
-            transaction_qty = min(tmp['required_quantity'], tmp['enable_quantity'])
+        for i in sells.index:
+            result += [self._execute_order(sells.loc[i].to_dict(), i)]
+            time.sleep(ORDER_INTERVAL_SECONDS)
 
-            if self.is_test is True:
-                response = {'msg1': 'TEST', 'rt_cd': '99'}
-            elif transaction_qty == 0:
-                response = {'msg1': '거래 가능 수량이 없습니다.', 'rt_cd': '99'}
-            else:
-                response = self.kis_agent.create_domestic_order(tmp['required_transaction'], tmp['ticker'], ord_qty=transaction_qty, ord_dvsn='01')
+        if sells.shape[0] > 0 and buys.shape[0] > 0:
+            logger.info('sell 완료. %s초 대기 후 buy 시작.', SELL_TO_BUY_WAIT_SECONDS)
+            time.sleep(SELL_TO_BUY_WAIT_SECONDS)
 
-            is_success = True if response['rt_cd'] == str(0) else False
-            tmp = {
-                'ticker': tmp['ticker'],
-                'enable_quantity': tmp['enable_quantity'],
-                'transaction_quantity': transaction_qty,
-                'is_success': is_success,
-                'response_msg': response['msg1'],
-                'transaction_order': i,
-            }
-            result += [tmp]
+        for i in buys.index:
+            result += [self._execute_order(buys.loc[i].to_dict(), i)]
+            time.sleep(ORDER_INTERVAL_SECONDS)
+
         return pd.DataFrame(result)
+
+    def _execute_order(self, tmp: dict, order_index: int) -> dict:
+        tmp['enable_quantity'] = self.get_enable_qty(ticker=tmp['ticker'], transaction_type=tmp['required_transaction'])
+        transaction_qty = min(tmp['required_quantity'], tmp['enable_quantity'])
+
+        if self.is_test is True:
+            response = {'msg1': 'TEST', 'rt_cd': '99'}
+        elif transaction_qty == 0:
+            response = {'msg1': '거래 가능 수량이 없습니다.', 'rt_cd': '99'}
+        else:
+            response = self.kis_client.create_domestic_order(tmp['required_transaction'], tmp['ticker'], ord_qty=transaction_qty, ord_dvsn='01')
+
+        is_success = True if response['rt_cd'] == str(0) else False
+        return {
+            'ticker': tmp['ticker'],
+            'enable_quantity': tmp['enable_quantity'],
+            'transaction_quantity': transaction_qty,
+            'is_success': is_success,
+            'response_msg': response['msg1'],
+            'transaction_order': order_index,
+        }
 
     def get_enable_qty(self, ticker: str, transaction_type: str) -> int:
         if transaction_type == 'buy':
-            return int(self.kis_agent.fetch_domestic_enable_buy(ticker=ticker, ord_dvsn='01')['nrcvb_buy_qty'])
+            return int(self.kis_client.fetch_domestic_enable_buy(ticker=ticker, ord_dvsn='01')['nrcvb_buy_qty'])
         elif transaction_type == 'sell':
-            return int(self.kis_agent.fetch_domestic_enable_sell(ticker=ticker)['ord_psbl_qty'])
+            return int(self.kis_client.fetch_domestic_enable_sell(ticker=ticker)['ord_psbl_qty'])
         raise ValueError(f"transaction_type must be 'buy' or 'sell', got: {transaction_type!r}")
 
     def get_rebalancing_plan(self) -> pd.DataFrame:
         allocation_info = self.allocation_info.copy()
-        allocation_info['current_price'] = allocation_info['ticker'].apply(self.kis_agent.fetch_price)
+        allocation_info['current_price'] = allocation_info['ticker'].apply(self.kis_client.fetch_price)
 
-        balance_info = self.kis_agent.fetch_domestic_total_balance().drop(columns=['stock_nm', 'current_price'])
+        balance_info = self.kis_client.fetch_domestic_total_balance().drop(columns=['stock_nm', 'current_price'])
 
         result = self.create_total_info(allocation=allocation_info, balance=balance_info)
         result = result.sort_values(by='required_value', ascending=True).reset_index(drop=True)


### PR DESCRIPTION
## Summary
- sell 완료 후 KIS API의 `ruse_psbl_amt`(전일/금일 매도대금) 반영을 기다리기 위해 `SELL_TO_BUY_WAIT_SECONDS = 30` 전역변수 추가
- 각 주문 사이 `ORDER_INTERVAL_SECONDS = 3` sleep 추가
- `run_rebalancing`을 sell/buy 그룹으로 명시적으로 분리하여 순서 보장
- `_execute_order` 헬퍼 메서드 추출로 중복 제거

## 배경
KIS 매수가능조회 API의 `nrcvb_buy_qty`는 `ord_psbl_cash`(예수금) + `ruse_psbl_amt`(당일 매도대금) 기반으로 계산됨. sell 체결 직후 `ruse_psbl_amt`가 즉시 반영되지 않는 경우 buy의 `enable_quantity = 0`이 되는 문제가 종종 발생. sell 그룹 완료 후 30초 대기로 해결.

## Test plan
- [ ] sell만 있는 경우 정상 동작 확인
- [ ] buy만 있는 경우 정상 동작 확인
- [ ] sell + buy 혼재 시 sell 완료 후 30초 대기 로그 확인
- [ ] buy의 `enable_quantity`가 0이 되는 현상 재발 여부 모니터링

🤖 Generated with [Claude Code](https://claude.com/claude-code)