### PR TITLE
feat: 리밸런싱 sell → buy 순서 보장 및 주문 간 대기 시간 추가

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
 
     obj = StaticAllocator(account_type=args.account_type, allocation_info=allocation_info)
 
-    is_market_open = obj.kis_agent.is_trading_day(kst_date)
+    is_market_open = obj.kis_client.is_trading_day(kst_date)
     latest_trade_date = pd.to_datetime(
         gs_client.get_df_from_google_sheets(f'{args.account_type}_trade_log')['update_dt']
     ).dt.date.unique()[0]


### PR DESCRIPTION
- sell 완료 후 KIS ruse_psbl_amt 반영 대기를 위해 SELL_TO_BUY_WAIT_SECONDS(30초) 추가
- 각 주문 간 ORDER_INTERVAL_SECONDS(3초) sleep 추가
- run_rebalancing을 sell/buy 그룹으로 명시적 분리
- _execute_order 헬퍼 메서드 추출