### PR TITLE
fix: wildcard import 제거 및 타입 어노테이션 수정

### DIFF
--- a/src/kis/client.py
+++ b/src/kis/client.py
@@ -8,7 +8,6 @@ from zoneinfo import ZoneInfo
 from datetime import date, datetime
 
 import pandas as pd
-from src.kis.stock_config import *
 from src.config.env import PROJECT_ROOT, load_kis_auth_config
 from src.logger import get_logger, log_method_call
 

--- a/src/sheets/client.py
+++ b/src/sheets/client.py
@@ -22,7 +22,7 @@ class GoogleSheetsClient():
         self.client = gspread.authorize(self.credential)
         self.spreadsheet = self.client.open_by_url(self.gs_url)
 
-    def get_worksheet(self, sheet) -> gspread.worksheet:
+    def get_worksheet(self, sheet) -> gspread.Worksheet:
         return self.spreadsheet.worksheet(sheet)
 
     def get_df_from_google_sheets(self, sheet) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- `src/kis/client.py`: 미사용 `from src.kis.stock_config import *` 제거 — `stock_config`의 어떤 심볼도 프로젝트 전체에서 실제 사용되지 않음
- `src/sheets/client.py`: `get_worksheet` 반환 타입을 `gspread.worksheet`(모듈) → `gspread.Worksheet`(클래스)로 수정

## Test plan
- [ ] `python main.py --account_type <type>` 실행 시 import 에러 없이 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)