### PR TITLE
fix: 매수 수량 계산 오류 및 예수금 조회 개선

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--account_type', type=str)
     parser.add_argument('--test', action='store_true', default=False)
+    parser.add_argument('--force', action='store_true', default=False)
     args = parser.parse_args()
 
     gs_client = GoogleSheetsClient(url=GOOGLE_SHEET_URL)
@@ -36,7 +37,7 @@ if __name__ == '__main__':
     print(f'- is_market_open: {is_market_open}')
     print(f'- is_already_executed: {is_already_executed}')
 
-    if args.test or (is_market_open and not is_already_executed):
+    if args.test or args.force or (is_market_open and not is_already_executed):
         result = obj.run()
         slack_notify(f'[{args.account_type}] 리밸런싱 결과', _format_result_for_slack(result))
         if not args.test:

--- a/src/allocation.py
+++ b/src/allocation.py
@@ -153,7 +153,7 @@ class StaticAllocator():
         if transaction_type == 'buy':
             result = self.kis_client.fetch_domestic_enable_buy(ticker=ticker, ord_dvsn='01')
             calc_price = int(result['psbl_qty_calc_unpr'])
-            available_amt = int(result['nrcvb_buy_amt']) + int(result['ruse_psbl_amt'])
+            available_amt = (int(result['nrcvb_buy_amt']) + int(result['ruse_psbl_amt'])) * 0.99
             return int(available_amt / calc_price) if calc_price > 0 else 0
         elif transaction_type == 'sell':
             return int(self.kis_client.fetch_domestic_enable_sell(ticker=ticker)['ord_psbl_qty'])

--- a/src/kis/client.py
+++ b/src/kis/client.py
@@ -149,9 +149,18 @@ class KISClient():
 
     @log_method_call
     def fetch_domestic_cash_balance(self) -> int:
-        """국내 계좌 예수금(원화 현금)을 조회한다."""
-        data = self._domestic_balance_page()
-        return int(data['output2'][0]['dnca_tot_amt'])
+        """국내 계좌 실질 현금을 조회한다.
+
+        dnca_tot_amt(결제 완료 예수금)에 당일 매도/매수 체결 금액을 반영해
+        실시간 실질 현금을 반환한다. 거래가 없는 날은 thdt_sll_amt와 thdt_buy_amt가
+        모두 0이므로 dnca_tot_amt 단독 값과 동일하다.
+        """
+        output2 = self._domestic_balance_page()['output2'][0]
+        return (
+            int(output2['dnca_tot_amt'])
+            + int(output2['thdt_sll_amt'])
+            - int(output2['thdt_buy_amt'])
+        )
 
     @log_method_call
     def fetch_domestic_stock_balance(self) -> dict:


### PR DESCRIPTION
## Summary

- 매수 가능 수량 계산 시 수수료 미반영으로 인한 주문가능금액 초과 오류 수정 (안전마진 1% 적용)
- `fetch_domestic_cash_balance`가 결제 완료 예수금만 반환하던 문제 수정 — 당일 매도/매수 체결금액을 반영해 실시간 실질 현금을 반환하도록 변경
- `--force` 옵션 추가로 `is_already_executed` 조건을 무시하고 강제 실행 가능

## Test plan

- [ ] `--test --force` 옵션으로 실행해 Slack 알림의 sell 전/후/buy 후 예수금 값이 의미 있는 값으로 출력되는지 확인
- [ ] 리밸런싱 실행 후 주문가능금액 초과 오류 없이 모든 종목 매수 주문이 정상 전송되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)