### PR TITLE
fix: ISA 매수 시 주문가능금액 초과 오류 수정

### DIFF
--- a/src/allocation.py
+++ b/src/allocation.py
@@ -111,7 +111,12 @@ class StaticAllocator():
         logger.info('buy 시작 전 예수금: %s', cash_before_buy)
         slack_notify(f'[{self.account_type}] sell 이후 예수금', f'`{cash_before_buy:,}원`')
 
-        remaining_cash = cash_before_buy
+        # dnca_tot_amt는 CMA 등 즉시 주문 불가 금액을 포함할 수 있어 API의 nrcvb_buy_amt 기준으로 추적한다.
+        if not buys.empty:
+            first_ticker = buys.loc[buys.index[0]]['ticker']
+            remaining_cash = self.kis_client.fetch_buy_orderable_cash(first_ticker)
+        else:
+            remaining_cash = cash_before_buy
         for i in buys.index:
             order_result = self._execute_order(buys.loc[i].to_dict(), i, available_cash=remaining_cash)
             # 체결 여부와 무관하게 API 반영 지연을 고려해 주문 금액을 즉시 차감
@@ -153,13 +158,17 @@ class StaticAllocator():
 
         매수의 경우:
         - available_cash가 전달되면 해당 값을 기준으로 수량을 계산한다 (연속 매수 시 잔여 현금 추적용).
-        - 전달되지 않으면 실시간 현금 잔고를 조회한다.
-        nrcvb_buy_amt는 당일 ETF 매도 대금(T+2 결제)을 반영하지 않으므로 사용하지 않는다.
+        - 전달되지 않으면 API의 nrcvb_buy_amt + ruse_psbl_amt를 사용한다.
+        dnca_tot_amt는 CMA 등 즉시 주문 불가 금액을 포함할 수 있어 사용하지 않는다.
         """
         if transaction_type == 'buy':
             result = self.kis_client.fetch_domestic_enable_buy(ticker=ticker, ord_dvsn='01')
             calc_price = int(result['psbl_qty_calc_unpr'])
-            cash_balance = available_cash if available_cash is not None else self.kis_client.fetch_domestic_cash_balance()
+            if available_cash is not None:
+                cash_balance = available_cash
+            else:
+                # available_cash 없이 단독 호출 시 API의 실제 주문 가능 금액을 사용
+                cash_balance = int(result['nrcvb_buy_amt']) + int(result['ruse_psbl_amt'])
             available_amt = cash_balance * 0.99
             logger.info(
                 '[%s] cash_balance=%s, available_amt=%s, calc_price=%s → enable_qty=%s',

--- a/src/kis/client.py
+++ b/src/kis/client.py
@@ -347,6 +347,26 @@ class KISClient():
         return self._get("uapi/domestic-stock/v1/trading/inquire-psbl-order", "TTTC8908R", params).json()['output']
 
     @log_method_call
+    def fetch_buy_orderable_cash(self, ticker: str) -> int:
+        """실제 매수 가능 현금을 조회한다.
+
+        API의 nrcvb_buy_amt(미수 없는 매수 가능 금액) + ruse_psbl_amt(재사용 가능 금액)에
+        당일 매도 대금(T+2 미반영분)을 합산한다.
+        dnca_tot_amt(예수금 총금액)는 CMA 등 즉시 주문 불가 금액을 포함할 수 있어 사용하지 않는다.
+        """
+        enable = self.fetch_domestic_enable_buy(ticker=ticker, ord_dvsn='01')
+        nrcvb = int(enable['nrcvb_buy_amt']) + int(enable['ruse_psbl_amt'])
+        balance = self._domestic_balance_page()['output2'][0]
+        thdt_sll_amt = int(balance['thdt_sll_amt'])
+        total = nrcvb + thdt_sll_amt
+        logger.info(
+            'buy_orderable: nrcvb=%s, ruse=%s, thdt_sll=%s → %s원 (dnca_tot=%s)',
+            enable['nrcvb_buy_amt'], enable['ruse_psbl_amt'],
+            thdt_sll_amt, total, balance['dnca_tot_amt'],
+        )
+        return total
+
+    @log_method_call
     def fetch_domestic_enable_sell(self, ticker: str) -> dict:
         """국내주식 매도 가능 수량을 조회한다."""
         params = {


### PR DESCRIPTION
## Summary
- ISA 계좌 매수 시 `dnca_tot_amt`(예수금 총금액) 대신 API의 `nrcvb_buy_amt + ruse_psbl_amt` 기준으로 주문가능금액을 추적하도록 수정
- CMA 등 즉시 주문 불가 금액을 포함할 수 있는 `dnca_tot_amt` 사용을 제거
- `fetch_buy_orderable_cash` 메서드 추가: `nrcvb_buy_amt + ruse_psbl_amt + thdt_sll_amt(당일 매도대금)` 합산으로 실제 주문 가능 금액 계산

## Root Cause
`dnca_tot_amt`는 CMA 연계 계좌의 경우 즉시 출금 불가 금액을 포함하여 실제 주문가능금액보다 크게 나타나, 이를 기준으로 매수 수량을 계산하면 주문가능금액 초과 오류 발생

## Test plan
- [ ] ISA 계좌에서 연속 매수 시 주문가능금액 초과 오류 미발생 확인
- [ ] `fetch_buy_orderable_cash` 로그에서 `nrcvb`, `ruse`, `thdt_sll` 합산값이 올바르게 출력되는지 확인
- [ ] 일반 계좌(non-ISA)에서 기존 동작 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)