### PR TITLE
refactor(trade_log): BEFORE/PLAN/EXEC/AFTER 스키마 + ACCOUNT 요약 행

### DIFF
--- a/src/allocation.py
+++ b/src/allocation.py
@@ -1,5 +1,7 @@
 import time
+from datetime import datetime
 import pandas as pd
+import pytz
 
 from src.kis.client import KISClient
 from src.logger import get_logger, log_method_call
@@ -9,13 +11,34 @@ logger = get_logger(__name__)
 # sell 완료 후 buy를 시작하기 전 대기 시간 (초). 매도 체결 후 예수금 반영까지 시간이 필요하다.
 SELL_TO_BUY_WAIT_SECONDS = 3
 BUFFER_CASH = 10_000  # 리밸런싱 후 최소 예수금 버퍼 (원)
+ACCOUNT_ROW_TICKER = 'ACCOUNT'  # 계좌 단위 요약 행을 식별하는 ticker 값
+
+# 거래 로그 컬럼 순서 (BEFORE → PLAN → EXEC → AFTER 블록 + 메타).
+# write_worksheet 호출 시 시트 헤더 순서를 결정한다.
+TRADE_LOG_COLUMNS = [
+    # META
+    'run_id', 'account_type', 'ticker', 'stock_nm', 'category_1', 'category_2',
+    # BEFORE
+    'before_price', 'before_quantity', 'before_value', 'before_pct', 'before_drift_pp',
+    # PLAN
+    'target_weight', 'target_value', 'required_value', 'required_quantity', 'required_transaction',
+    # EXEC
+    'enable_quantity', 'transaction_quantity', 'exec_price', 'exec_value',
+    'skipped_reason', 'is_success', 'response_msg', 'transaction_order',
+    # AFTER
+    'after_quantity', 'after_value', 'after_pct', 'after_drift_pp', 'drift_reduction_pp',
+    # ACCOUNT 전용 요약 컬럼 (per-ticker 행에서는 비어있음)
+    'cash_before_sell', 'cash_after_sell', 'cash_after_buy',
+    'n_buy_orders', 'n_sell_orders', 'n_failed',
+]
+
 
 def _format_stock_header(row) -> str:
     return (
         f"*[{row['stock_nm']}: `{row['ticker']}`]*\n"
-        f"- current_price: `{row['current_price']:,.0f}`\n"
-        f"- current_quantity: `{row['current_quantity']:,.0f}`\n"
-        f"- current_value: `{row['current_value']:,.0f}` (`{row['current_pct']:.2f}%` → 목표: `{row['weight']*100:.2f}%`)"
+        f"- before_price: `{row['before_price']:,.0f}`\n"
+        f"- before_quantity: `{row['before_quantity']:,.0f}`\n"
+        f"- before_value: `{row['before_value']:,.0f}` (`{row['before_pct']:.2f}%` → 목표: `{row['target_weight']*100:.2f}%`)"
     )
 
 
@@ -34,9 +57,12 @@ def _format_plan_for_slack(df: pd.DataFrame) -> str:
 
 
 def _format_result_for_slack(df: pd.DataFrame) -> str:
-    """리밸런싱 실행 결과 DataFrame을 Slack 메시지 형식의 문자열로 변환한다."""
+    """리밸런싱 실행 결과 DataFrame을 Slack 메시지 형식의 문자열로 변환한다.
+
+    ACCOUNT 요약 행은 종목 포맷과 스키마가 달라 제외한다.
+    """
     lines = []
-    for _, row in df.iterrows():
+    for _, row in df[df['ticker'] != ACCOUNT_ROW_TICKER].iterrows():
         lines.append(
             _format_stock_header(row) + "\n"
             f"- required_transaction: `{row['required_transaction']}`\n"
@@ -83,6 +109,8 @@ class PortfolioPlanner:
             raise ValueError(
                 f"총 평가금액({total_balance_value:,.0f}원)이 버퍼({BUFFER_CASH:,}원) 이하입니다. 리밸런싱 중단."
             )
+        # ACCOUNT 요약 행에서 사용하기 위해 보관
+        self.total_value_before = float(total_balance_value)
         logger.info('총 평가금액 (예수금 포함): %s원', f'{total_balance_value:,.0f}')
         slack_notify(f'[{self.account_type}] 총 평가금액 (예수금 포함)', f'`{total_balance_value:,.0f}원`')
 
@@ -102,6 +130,17 @@ class PortfolioPlanner:
         result['required_quantity'] = abs((result['required_value'] / result['current_price']).astype(int))
         result['required_transaction'] = result['required_value'].apply(lambda x: 'buy' if x > 0 else 'sell' if x < 0 else None)
         result['current_pct'] = result['current_value'] / total_balance_value * 100
+
+        # 로그 스키마용 명명 규약으로 일괄 rename. 이후 코드(executor 포함)는 before_*/target_weight를 사용한다.
+        result = result.rename(columns={
+            'weight': 'target_weight',
+            'current_price': 'before_price',
+            'current_quantity': 'before_quantity',
+            'current_value': 'before_value',
+            'current_pct': 'before_pct',
+        })
+        # 리밸런싱 직전 목표 대비 편차 (단위: %p). 양수=초과 보유, 음수=과소 보유.
+        result['before_drift_pp'] = result['before_pct'] - result['target_weight'] * 100
         return result
 
     @log_method_call
@@ -129,14 +168,20 @@ class PortfolioPlanner:
         if not unallocated.empty:
             logger.info('allocation 미등록 종목 전량 매도 대상: %s', unallocated['ticker'].tolist())
             total_balance = full_balance['current_value'].sum()
+            unallocated = unallocated.rename(columns={
+                'current_price': 'before_price',
+                'current_quantity': 'before_quantity',
+                'current_value': 'before_value',
+            })
             unallocated['category_1'] = None
             unallocated['category_2'] = None
-            unallocated['weight'] = 0.0
+            unallocated['target_weight'] = 0.0
             unallocated['target_value'] = 0.0
-            unallocated['required_value'] = -unallocated['current_value']
-            unallocated['required_quantity'] = unallocated['current_quantity'].astype(int)
+            unallocated['required_value'] = -unallocated['before_value']
+            unallocated['required_quantity'] = unallocated['before_quantity'].astype(int)
             unallocated['required_transaction'] = 'sell'
-            unallocated['current_pct'] = unallocated['current_value'] / total_balance * 100
+            unallocated['before_pct'] = unallocated['before_value'] / total_balance * 100
+            unallocated['before_drift_pp'] = unallocated['before_pct'] - unallocated['target_weight'] * 100
             result = pd.concat([result, unallocated[result.columns]], ignore_index=True)
 
         result = result.sort_values(by='required_value', ascending=True).reset_index(drop=True)
@@ -152,11 +197,15 @@ class OrderExecutor:
         self.is_test = is_test
 
     @log_method_call
-    def run_rebalancing(self, plan_df: pd.DataFrame) -> pd.DataFrame:
+    def run_rebalancing(self, plan_df: pd.DataFrame) -> tuple[pd.DataFrame, dict]:
         """리밸런싱 플랜에 따라 매도 → 매수 순서로 주문을 실행한다.
 
         매도를 먼저 실행해 예수금을 확보한 뒤 매수를 진행한다.
         sell/buy 사이에는 체결 후 예수금 반영 대기를 위해 sleep한다.
+
+        Returns:
+            (trade_log, cash_summary): 종목별 실행 결과 DataFrame과
+            sell 전/후 및 buy 후 예수금 스냅샷.
         """
         sells = plan_df[plan_df['required_transaction'] == 'sell']
         buys = plan_df[plan_df['required_transaction'] == 'buy']
@@ -174,25 +223,30 @@ class OrderExecutor:
             logger.info('sell 완료. %s초 대기 후 buy 시작.', SELL_TO_BUY_WAIT_SECONDS)
             time.sleep(SELL_TO_BUY_WAIT_SECONDS)
 
-        cash_before_buy = self.kis_client.fetch_domestic_cash_balance()
-        logger.info('buy 시작 전 예수금: %s', cash_before_buy)
-        slack_notify(f'[{self.account_type}] sell 이후 예수금', f'`{cash_before_buy:,}원`')
+        cash_after_sell = self.kis_client.fetch_domestic_cash_balance()
+        logger.info('buy 시작 전 예수금: %s', cash_after_sell)
+        slack_notify(f'[{self.account_type}] sell 이후 예수금', f'`{cash_after_sell:,}원`')
 
         # dnca_tot_amt는 CMA 등 즉시 주문 불가 금액을 포함할 수 있어 API의 nrcvb_buy_amt 기준으로 추적한다.
         if not buys.empty:
             first_ticker = buys.loc[buys.index[0]]['ticker']
             remaining_cash = self.kis_client.fetch_buy_orderable_cash(first_ticker)
         else:
-            remaining_cash = cash_before_buy
+            remaining_cash = cash_after_sell
         for i in buys.index:
             order_result = self._execute_order(buys.loc[i].to_dict(), i, available_cash=remaining_cash)
             # 체결 여부와 무관하게 API 반영 지연을 고려해 주문 금액을 즉시 차감
-            remaining_cash -= order_result['transaction_quantity'] * int(buys.loc[i]['current_price'])
+            remaining_cash -= order_result['transaction_quantity'] * int(buys.loc[i]['before_price'])
             result.append(order_result)
         cash_after_buy = self.kis_client.fetch_domestic_cash_balance()
         logger.info('buy 완료 후 예수금: %s', cash_after_buy)
         slack_notify(f'[{self.account_type}] buy 완료 후 예수금', f'`{cash_after_buy:,}원`')
-        return pd.DataFrame(result)
+        cash_summary = {
+            'cash_before_sell': cash_before_sell,
+            'cash_after_sell': cash_after_sell,
+            'cash_after_buy': cash_after_buy,
+        }
+        return pd.DataFrame(result), cash_summary
 
     def _execute_order(self, plan_row: dict, order_index: int, available_cash: int = None) -> dict:
         """단일 종목의 주문을 실행하고 결과를 dict로 반환한다.
@@ -221,6 +275,9 @@ class OrderExecutor:
             'ticker': plan_row['ticker'],
             'enable_quantity': enable_qty,
             'transaction_quantity': transaction_qty,
+            # 체결조회 API 미연동 상태. 평균 체결가/체결금액을 채워넣을 자리만 우선 확보한다.
+            'exec_price': None,
+            'exec_value': None,
             'skipped_reason': skipped_reason,
             'is_success': response['rt_cd'] == '0' if response else None,  # KIS API 성공 코드는 '0'
             'response_msg': response['msg1'] if response else None,
@@ -266,16 +323,88 @@ class StaticAllocator:
         self.account_type = account_type
         self.allocation_info = allocation_info
         self.is_test = is_test
-        kis_client = KISClient(account_type)
-        self.planner = PortfolioPlanner(kis_client, allocation_info, account_type)
-        self.executor = OrderExecutor(kis_client, account_type, is_test)
+        self.kis_client = KISClient(account_type)
+        self.planner = PortfolioPlanner(self.kis_client, allocation_info, account_type)
+        self.executor = OrderExecutor(self.kis_client, account_type, is_test)
 
     @log_method_call
     def run(self) -> pd.DataFrame:
-        """리밸런싱 전체 플로우를 실행하고 플랜 + 실행 결과를 합산한 DataFrame을 반환한다."""
+        """리밸런싱 전체 플로우를 실행하고 BEFORE/PLAN/EXEC/AFTER + ACCOUNT 행을 합산한 DataFrame을 반환한다."""
+        run_id = datetime.now(pytz.timezone('Asia/Seoul')).strftime('%Y-%m-%d %H:%M:%S')
+
         total_info = self.planner.get_rebalancing_plan()
         logger.info('total_info:\n%s', total_info.to_string())
         slack_notify(f'[{self.account_type}] 리밸런싱 플랜', _format_plan_for_slack(total_info))
-        trade_log = self.executor.run_rebalancing(plan_df=total_info)
-        # 플랜(total_info)과 실행 결과(trade_log)를 ticker 기준으로 합산해 반환
-        return total_info.merge(trade_log, on='ticker', how='outer')
+
+        trade_log, cash_summary = self.executor.run_rebalancing(plan_df=total_info)
+
+        # 매수 체결이 잔고에 반영될 때까지 잠시 대기 후 사후 스냅샷 조회
+        time.sleep(SELL_TO_BUY_WAIT_SECONDS)
+        after_snapshot, total_value_after = self._fetch_after_snapshot()
+
+        merged = total_info.merge(trade_log, on='ticker', how='outer')
+        merged = merged.merge(after_snapshot, on='ticker', how='left')
+        # 매도로 잔고가 0이 된 종목은 after_snapshot에 없을 수 있어 0으로 채운다.
+        merged[['after_quantity', 'after_value']] = merged[['after_quantity', 'after_value']].fillna(0)
+        merged['after_pct'] = merged['after_value'] / total_value_after * 100
+        merged['after_drift_pp'] = merged['after_pct'] - merged['target_weight'] * 100
+        # 양수 = 목표에 더 가까워짐. 음수 = 더 멀어짐.
+        merged['drift_reduction_pp'] = merged['before_drift_pp'].abs() - merged['after_drift_pp'].abs()
+
+        merged['run_id'] = run_id
+        merged['account_type'] = self.account_type
+
+        account_row = self._build_account_row(
+            run_id=run_id,
+            plan_df=total_info,
+            trade_log=trade_log,
+            total_value_after=total_value_after,
+            cash_summary=cash_summary,
+        )
+        merged = pd.concat([merged, pd.DataFrame([account_row])], ignore_index=True)
+
+        # 컬럼이 누락되어도 안전하도록 존재하는 컬럼만 정렬해 반환한다.
+        ordered = [c for c in TRADE_LOG_COLUMNS if c in merged.columns]
+        extras = [c for c in merged.columns if c not in ordered]
+        return merged[ordered + extras]
+
+    def _fetch_after_snapshot(self) -> tuple[pd.DataFrame, float]:
+        """리밸런싱 직후 잔고를 조회해 종목별 사후 수량/금액과 총 평가금액을 반환한다."""
+        full = self.kis_client.fetch_domestic_total_balance()
+        total_value_after = float(full['current_value'].sum())
+        per_ticker = full[full['ticker'] != 'CASH'][['ticker', 'current_quantity', 'current_value']].rename(
+            columns={'current_quantity': 'after_quantity', 'current_value': 'after_value'}
+        )
+        return per_ticker, total_value_after
+
+    def _build_account_row(
+        self,
+        run_id: str,
+        plan_df: pd.DataFrame,
+        trade_log: pd.DataFrame,
+        total_value_after: float,
+        cash_summary: dict,
+    ) -> dict:
+        """계좌 단위 요약 행(ticker='ACCOUNT')을 구성한다.
+
+        per-ticker와 다른 메트릭(현금 스냅샷, 주문 카운트)을 한 행에 모아 한 번의 리밸런싱
+        결과를 시트에서 한 줄로 검증할 수 있게 한다.
+        """
+        is_success = trade_log['is_success'] if 'is_success' in trade_log.columns else pd.Series(dtype='object')
+        return {
+            'run_id': run_id,
+            'account_type': self.account_type,
+            'ticker': ACCOUNT_ROW_TICKER,
+            'stock_nm': 'SUMMARY',
+            'before_value': self.planner.total_value_before,
+            'before_pct': 100.0,
+            'target_weight': 1.0,
+            'after_value': total_value_after,
+            'after_pct': 100.0,
+            'cash_before_sell': cash_summary['cash_before_sell'],
+            'cash_after_sell': cash_summary['cash_after_sell'],
+            'cash_after_buy': cash_summary['cash_after_buy'],
+            'n_buy_orders': int((plan_df['required_transaction'] == 'buy').sum()),
+            'n_sell_orders': int((plan_df['required_transaction'] == 'sell').sum()),
+            'n_failed': int((is_success == False).sum()),  # noqa: E712 — pandas Series 비교는 == 사용
+        }


### PR DESCRIPTION
## 배경

월단위 리밸런싱의 **이전/이후 차이**를 시트만으로 검증할 수 있도록 `{PPA/ISA}_trade_log` 스키마를 개편한다. 기존 로그는 BEFORE 상태 + 계획 + 주문 성공 여부까지만 기록되어, "리밸런싱 후 실제 비중이 목표와 얼마나 일치했나"를 사후에 확인할 수 없었다.

## 변경 내용

### 컬럼 스키마 (`src/allocation.py:TRADE_LOG_COLUMNS`)

```
[META]    run_id, account_type, ticker, stock_nm, category_1, category_2
[BEFORE]  before_price, before_quantity, before_value, before_pct, before_drift_pp
[PLAN]    target_weight, target_value, required_value, required_quantity, required_transaction
[EXEC]    enable_quantity, transaction_quantity, exec_price, exec_value,
          skipped_reason, is_success, response_msg, transaction_order
[AFTER]   after_quantity, after_value, after_pct, after_drift_pp, drift_reduction_pp
[ACCOUNT] cash_before_sell, cash_after_sell, cash_after_buy, n_buy_orders, n_sell_orders, n_failed
[AUTO]    update_dt   ← write_worksheet 가 자동 추가
```

### 주요 변경

- `current_*` → `before_*`, `weight` → `target_weight` 일괄 rename
- `before_drift_pp` (목표 대비 사전 편차, %p) 추가
- 실행 직후 `fetch_domestic_total_balance` 한 번 더 호출해 `after_quantity/value/pct` 채움 (체결 반영을 위해 3초 sleep)
- `after_drift_pp`, `drift_reduction_pp = |before_drift_pp| − |after_drift_pp|` (양수면 목표에 더 가까워짐)
- `run_id` (KST 타임스탬프) 메타 컬럼으로 한 배치 식별
- `ticker='ACCOUNT'` 요약 행에 총 평가금액 BEFORE/AFTER, 현금 스냅샷 3종, 매수/매도/실패 카운트 기록
- `exec_price`, `exec_value` 컬럼만 미리 만들고 값은 `null` (체결조회 API 미연동 — 추후 작업)
- `_format_result_for_slack` 가 ACCOUNT 행을 자동 필터
- `StaticAllocator.kis_client` 노출 (`main.is_trading_day` 호출부 정상화 — 기존 잠재 버그)

## 시트 마이그레이션

헤더가 바뀌므로 **`PPA_trade_log`, `ISA_trade_log` 두 탭을 삭제** 후 다음 실행 시 자동 재생성. `write_worksheet` 가 시트 부재 시 새로 만드는 동작이라 코드 변경 없이 처리됨.

## Test plan

- [ ] 1단계 드라이런: `python main.py --account_type PPA --test --force`
  - KeyError/스키마 깨짐 없이 슬랙 메시지 정상 출력 확인
  - 슬랙 결과 메시지에 ACCOUNT 행이 노출되지 않는지 확인
- [ ] 2단계 ISA도 동일 명령 반복
- [ ] 3단계 (거래일 실제 운영) 시트 정합성:
  - 종목 행 `before_value` 합 + ACCOUNT.`cash_before_sell` ≈ ACCOUNT.`before_value`
  - 종목 행 `after_value` 합 + ACCOUNT.`cash_after_buy` ≈ ACCOUNT.`after_value`
  - 매수/매도 발생 종목은 `|after_drift_pp| < |before_drift_pp|`
  - 같은 `run_id` 값이 한 배치 내 모든 행에 동일

## 후속 작업 (별도 PR)

- 체결조회 API 연동해 `exec_price` / `exec_value` 실값 채우기
- `allocation.py` 단위 테스트 (`_create_total_info`, `_build_account_row`, unallocated sell-all 경로)

https://claude.ai/code/session_01GAHhRTgMSAViSwKQDfUeCd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GAHhRTgMSAViSwKQDfUeCd)_