### PR TITLE
feat(slack): IRP 리밸런싱 메시지를 SELL/BUY 섹션 분리 양식으로 재작성

### DIFF
--- a/src/slack/client.py
+++ b/src/slack/client.py
@@ -185,6 +185,29 @@ _IRP_PLAN_REQUIRED_COLUMNS = (
     'ticker', 'required_transaction', 'required_quantity', 'weight', 'current_pct',
 )
 
+_IRP_DIVIDER = '━' * 14
+_IRP_SHEET_LINK_LABEL = 'IRP_action_plan 시트 보기 →'
+
+
+def _format_irp_section(rows: pd.DataFrame, title: str, emoji: str, *, is_sell: bool) -> list:
+    """IRP 섹션(SELL/BUY) 라인 빌더. rows가 비면 빈 리스트 반환(섹션 전체 생략)."""
+    if rows.empty:
+        return []
+    lines = [_IRP_DIVIDER, f'{emoji} {title}', _IRP_DIVIDER, '']
+    for _, row in rows.iterrows():
+        ticker  = str(row['ticker'])
+        nm      = str(row.get('stock_nm', ticker))
+        qty     = int(row['required_quantity'])
+        signed  = -qty if is_sell else qty
+        tgt_pct = float(row['weight']) * 100
+        cur_pct = float(row['current_pct'])
+        delta   = tgt_pct - cur_pct
+        lines.append(f'[{ticker}] {nm}')
+        lines.append(f'{signed:+d}주')
+        lines.append(f'{cur_pct:.1f}% → {tgt_pct:.1f}% ({delta:+.1f}%)')
+        lines.append('')
+    return lines
+
 
 def format_irp_plan_summary(
     plan_df: pd.DataFrame,
@@ -196,55 +219,53 @@ def format_irp_plan_summary(
 
     IRP는 KIS API로 자동 매매가 불가능해 거래 실행 없이 플랜만 생성된다.
     사용자는 시트의 IRP_action_plan을 보고 KIS 앱에서 수동 매수/매도한다.
-    포맷: 헤더 + 매수/매도 카운트 + 종목별 액션 + 시트 URL.
+    포맷: 헤더 + 총 카운트 + SELL 섹션 + BUY 섹션 + 시트 URL.
+    섹션 내부는 |target_pct - current_pct| 내림차순 정렬 (큰 변동 우선 노출).
 
     필수 컬럼이 누락되면 KeyError로 즉시 실패 (silent failure 방지).
     required_quantity가 0인 행은 출력에서 제외 (KOFR buy 0주 같은 헷갈리는 표기 방지).
     """
-    # 필수 컬럼 검증 — 누락 시 KeyError로 즉시 폭발 (silent 위장 방지)
     missing = [c for c in _IRP_PLAN_REQUIRED_COLUMNS if c not in plan_df.columns]
     if missing:
         raise KeyError(f'format_irp_plan_summary 필수 컬럼 누락: {missing}')
 
-    if hasattr(dt, 'strftime'):
-        dt_str = dt.strftime('%Y-%m-%d %H:%M KST') if hasattr(dt, 'hour') else dt.strftime('%Y-%m-%d') + ' KST'
-    else:
-        dt_str = str(dt)
+    date_str = dt.strftime('%Y-%m-%d') if hasattr(dt, 'strftime') else str(dt)
+    header = f'📌 {account_type} 리밸런싱 플랜: {date_str}'
 
     df = plan_df[plan_df['ticker'] != 'CASH'].copy()
-    # required_transaction이 buy/sell이고 required_quantity > 0인 행만 (변동 0인 종목 제외)
     df['required_quantity'] = pd.to_numeric(df['required_quantity'], errors='coerce').fillna(0).astype(int)
     actionable = df[
         df['required_transaction'].isin(['buy', 'sell']) & (df['required_quantity'] > 0)
-    ]
-
-    buy_rows = actionable[actionable['required_transaction'] == 'buy']
-    sell_rows = actionable[actionable['required_transaction'] == 'sell']
-
-    lines = [
-        f'*[{account_type}] IRP 리밸런싱 플랜 생성* · {dt_str}',
-        f'IRP는 자동 매매 불가 — KIS 앱에서 수동으로 매수/매도 진행하세요.',
-        f'매수 {len(buy_rows)}건 · 매도 {len(sell_rows)}건 (CASH·변동 없음 제외)',
-    ]
-    if sheet_url:
-        lines.append(f'<{sheet_url}|IRP_action_plan 시트 보기 →>')
-    lines.append('')
+    ].copy()
 
     if actionable.empty:
-        lines.append('_플랜 변동 사항 없음 — 현재 비중이 목표와 일치._')
+        lines = [header, '', '변동 없음 (현재 비중 = 목표)']
+        if sheet_url:
+            lines.append('')
+            lines.append(f'<{sheet_url}|{_IRP_SHEET_LINK_LABEL}>')
         return '\n'.join(lines)
 
-    for _, row in actionable.iterrows():
-        nm     = str(row.get('stock_nm', row['ticker']))
-        ticker = str(row['ticker'])
-        action = str(row['required_transaction']).upper()
-        qty    = int(row['required_quantity'])
-        tgt_pct = float(row['weight']) * 100
-        cur_pct = float(row['current_pct'])
-        action_emoji = '🟢' if action == 'BUY' else '🔴'
-        lines.append(
-            f'{action_emoji} *{nm}* ({ticker}) — {action} `{qty}`주\n'
-            f'  목표 {tgt_pct:.1f}% · 현재 {cur_pct:.1f}%'
-        )
+    # 비중 변동량 절댓값 내림차순 + 동률 시 ticker 오름차순 (안정적 표시)
+    actionable['_abs_delta'] = (actionable['weight'] * 100 - actionable['current_pct']).abs()
+    actionable = actionable.sort_values(['_abs_delta', 'ticker'], ascending=[False, True])
+
+    sell_rows = actionable[actionable['required_transaction'] == 'sell']
+    buy_rows  = actionable[actionable['required_transaction'] == 'buy']
+
+    lines = [
+        header,
+        '',
+        f'총 {len(actionable)}건',
+        f'🟢 매수 {len(buy_rows)}건 · 🔴 매도 {len(sell_rows)}건',
+        '',
+    ]
+    lines.extend(_format_irp_section(sell_rows, 'SELL', '🔴', is_sell=True))
+    lines.extend(_format_irp_section(buy_rows,  'BUY',  '🟢', is_sell=False))
+
+    while lines and lines[-1] == '':
+        lines.pop()
+    if sheet_url:
+        lines.append('')
+        lines.append(f'<{sheet_url}|{_IRP_SHEET_LINK_LABEL}>')
 
     return '\n'.join(lines)

--- a/test/test_irp_plan.py
+++ b/test/test_irp_plan.py
@@ -233,7 +233,7 @@ def test_overwrite_dataframe_empty_df_writes_only_header():
 # ---------------------------------------------------------------------------- #
 
 def test_format_irp_plan_summary_includes_header_and_url():
-    """IRP 포맷 헤더, 매수/매도 카운트, 시트 URL 모두 포함."""
+    """IRP 포맷 헤더(📌 + account_type + 날짜), 카운트, 섹션 헤더, 시트 URL 포함."""
     from src.slack.client import format_irp_plan_summary
     from datetime import datetime
     import pytz
@@ -258,17 +258,58 @@ def test_format_irp_plan_summary_includes_header_and_url():
         sheet_url='https://docs.google.com/spreadsheets/d/abc#gid=123',
     )
 
-    assert '[IRP] IRP 리밸런싱 플랜 생성' in summary, 'IRP 헤더 누락'
-    assert '자동 매매 불가' in summary, '수동 매매 안내 누락'
-    assert '매수 1건' in summary
-    assert '매도 1건' in summary
-    assert 'IRP_action_plan 시트 보기' in summary, '시트 URL 링크 누락'
-    assert 'https://docs.google.com/spreadsheets/d/abc#gid=123' in summary
-    assert '삼성전자' in summary and 'BUY' in summary
-    assert 'SK하이닉스' in summary and 'SELL' in summary
+    assert '📌 IRP 리밸런싱 플랜: 2026-05-09' in summary, '새 헤더(이모지+account_type+날짜) 누락'
+    assert '총 2건' in summary, '총 카운트 라인 누락'
+    assert '🟢 매수 1건 · 🔴 매도 1건' in summary, '매수/매도 카운트 라인 누락'
+    assert '🔴 SELL' in summary and '🟢 BUY' in summary, '섹션 헤더 누락'
+    assert '━' * 14 in summary, '구분선 누락'
+    assert '[005930] 삼성전자' in summary, 'BUY 종목 라인 누락'
+    assert '[000660] SK하이닉스' in summary, 'SELL 종목 라인 누락'
+    assert '+5주' in summary, 'BUY 수량 부호 누락'
+    assert '-2주' in summary, 'SELL 수량 부호 누락'
+    # 비중 라인: cur% → tgt% (±Δ%) — 삼성전자 25.0→30.0 (+5.0)
+    assert '25.0% → 30.0% (+5.0%)' in summary
+    # SK하이닉스 30.0→20.0 (-10.0)
+    assert '30.0% → 20.0% (-10.0%)' in summary
+    assert f'<https://docs.google.com/spreadsheets/d/abc#gid=123|IRP_action_plan 시트 보기 →>' in summary
+    # SELL 섹션이 BUY 섹션보다 먼저 와야 함
+    assert summary.index('🔴 SELL') < summary.index('🟢 BUY'), 'SELL이 BUY보다 먼저 와야 함'
     # CASH 행은 출력에서 제외돼야 함
     assert 'WON_DEPOSIT' not in summary
-    print('✅ format_irp_plan_summary: 헤더 + 매수/매도 카운트 + 시트 URL + 종목 액션 포함')
+    # 기존 메시지 잔재가 남지 않아야 함
+    assert '자동 매매 불가' not in summary, '구버전 안내 문구 잔재'
+    assert '플랜 생성' not in summary, '구버전 헤더 잔재'
+    print('✅ format_irp_plan_summary: 새 양식 헤더/카운트/섹션/종목/링크/순서 모두 검증')
+
+
+def test_format_irp_plan_summary_sorts_by_abs_delta_desc():
+    """섹션 내부는 |target - current| 절댓값 내림차순으로 정렬."""
+    from src.slack.client import format_irp_plan_summary
+    from datetime import datetime
+
+    plan_df = pd.DataFrame([
+        # SELL: 절댓값 0.5, 4.0, 1.5 → 정렬 후 4.0, 1.5, 0.5
+        {'ticker': 'AAA', 'stock_nm': 'A주식',
+         'required_transaction': 'sell', 'required_quantity': 1,
+         'weight': 0.10, 'current_pct': 10.5},  # delta -0.5
+        {'ticker': 'BBB', 'stock_nm': 'B주식',
+         'required_transaction': 'sell', 'required_quantity': 2,
+         'weight': 0.06, 'current_pct': 10.0},  # delta -4.0
+        {'ticker': 'CCC', 'stock_nm': 'C주식',
+         'required_transaction': 'sell', 'required_quantity': 3,
+         'weight': 0.085, 'current_pct': 10.0},  # delta -1.5
+    ])
+
+    summary = format_irp_plan_summary(
+        plan_df=plan_df, account_type='IRP',
+        dt=datetime(2026, 5, 9), sheet_url=None,
+    )
+
+    pos_b = summary.index('[BBB]')
+    pos_c = summary.index('[CCC]')
+    pos_a = summary.index('[AAA]')
+    assert pos_b < pos_c < pos_a, f'절댓값 내림차순(B<C<A) 기대, 실제 위치 B={pos_b} C={pos_c} A={pos_a}'
+    print('✅ format_irp_plan_summary: 섹션 내부 |Δ| 내림차순 정렬')
 
 
 def test_format_irp_plan_summary_excludes_zero_quantity():
@@ -295,9 +336,10 @@ def test_format_irp_plan_summary_excludes_zero_quantity():
 
     assert '삼성전자' in summary, 'qty>0 종목은 포함'
     assert 'KOFR' not in summary, 'qty=0 종목은 출력 제외 (BUY 0주는 헷갈림)'
-    assert '매수 1건' in summary, '카운트도 qty>0만 반영'
-    assert '매도 0건' in summary
-    print('✅ format_irp_plan_summary: required_quantity=0 종목 출력 제외 + 카운트 정확 (P3)')
+    assert '🟢 매수 1건 · 🔴 매도 0건' in summary, '카운트도 qty>0만 반영'
+    # SELL 섹션은 0건이므로 헤더 자체가 없어야 함
+    assert '🔴 SELL' not in summary, '한쪽이 0건이면 그 섹션 전체 생략'
+    print('✅ format_irp_plan_summary: required_quantity=0 종목 출력 제외 + 0건 섹션 생략 (P3)')
 
 
 def test_format_irp_plan_summary_raises_on_missing_required_column():
@@ -345,9 +387,12 @@ def test_format_irp_plan_summary_empty_plan():
         sheet_url=None,  # URL 없는 케이스
     )
 
-    assert '매수 0건' in summary and '매도 0건' in summary
-    assert '플랜 변동 사항 없음' in summary
+    assert '📌 IRP 리밸런싱 플랜: 2026-05-09' in summary, '빈 케이스에도 헤더는 표시'
+    assert '변동 없음 (현재 비중 = 목표)' in summary, '빈 케이스 안내 문구'
     assert '시트 보기' not in summary  # URL None이면 링크 부재
+    # 빈 케이스에는 섹션/카운트 라인이 없어야 깔끔
+    assert '🔴 SELL' not in summary and '🟢 BUY' not in summary, '빈 케이스에 섹션 헤더 부재'
+    assert '총 ' not in summary, '빈 케이스에 카운트 라인 부재'
     print('✅ format_irp_plan_summary: 변동 없는 플랜 + URL 부재 케이스')
 
 
@@ -373,6 +418,7 @@ if __name__ == '__main__':
     test_overwrite_dataframe_creates_missing_sheet()
     test_overwrite_dataframe_empty_df_writes_only_header()
     test_format_irp_plan_summary_includes_header_and_url()
+    test_format_irp_plan_summary_sorts_by_abs_delta_desc()
     test_format_irp_plan_summary_excludes_zero_quantity()
     test_format_irp_plan_summary_raises_on_missing_required_column()
     test_format_irp_plan_summary_empty_plan()


### PR DESCRIPTION
- 헤더를 '📌 {account_type} 리밸런싱 플랜: {YYYY-MM-DD}'로 단순화
- 카운트 라인을 '총 N건' + '🟢 매수 B건 · 🔴 매도 S건' 두 줄로 분리
- SELL → BUY 순으로 섹션 헤더(━ 구분선) 묶음 + 한쪽 0건이면 섹션 통째 생략
- 종목 블록을 '[ticker] name / ±qty주 / cur% → tgt% (±Δ%)' 3줄 양식으로
- 섹션 내부는 |target_pct - current_pct| 내림차순(동률 시 ticker 오름차순)
- 시트 링크는 메시지 맨 아래로 이동
- 빈 케이스는 '변동 없음 (현재 비중 = 목표)'로 간결화